### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/connector-kafka2ftp.yml
+++ b/.github/workflows/connector-kafka2ftp.yml
@@ -58,7 +58,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.11
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/kafka2ftp
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/connector-mqtt-vernemq-broker.yml
+++ b/.github/workflows/connector-mqtt-vernemq-broker.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.16
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/vernemq-dojot
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/influxdb-retriever.yaml
+++ b/.github/workflows/influxdb-retriever.yaml
@@ -58,7 +58,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.16
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/influxdb-retriever
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/influxdb-storer.yaml
+++ b/.github/workflows/influxdb-storer.yaml
@@ -58,7 +58,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.16
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/influxdb-storer
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/k2v-bridge.yml
+++ b/.github/workflows/k2v-bridge.yml
@@ -58,7 +58,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.16
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/k2v-bridge
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/kafka-ws.yml
+++ b/.github/workflows/kafka-ws.yml
@@ -67,7 +67,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.16
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/kafka-ws
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/locust.yaml
+++ b/.github/workflows/locust.yaml
@@ -65,7 +65,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.16
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/locust
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/tools-kafka-loopback.yml
+++ b/.github/workflows/tools-kafka-loopback.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.16
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/kafka-loopback
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/v2k-bridge.yml
+++ b/.github/workflows/v2k-bridge.yml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@2.16
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ steps.get_owner.outputs.owner }}/v2k-bridge
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/x509-identity-mgmt.yml
+++ b/.github/workflows/x509-identity-mgmt.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Build and Push
-        uses: elgohr/Publish-Docker-Github-Action@2.16
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ steps.get_owner.outputs.owner }}/x509-identity-mgmt
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore